### PR TITLE
autotarget for everyone

### DIFF
--- a/src/map/entities/battleentity.cpp
+++ b/src/map/entities/battleentity.cpp
@@ -43,6 +43,8 @@
 #include "../packets/action.h"
 #include "../utils/petutils.h"
 #include "../utils/puppetutils.h"
+#include "../entities/mobentity.h"
+#include "../enmity_container.h"
 
 CBattleEntity::CBattleEntity()
 {
@@ -497,6 +499,20 @@ int32 CBattleEntity::addHP(int32 hp)
     if (health.hp == 0 && m_unkillable)
     {
         health.hp = 1;
+    }
+
+    // if dead mob, autotarget
+    if (health.hp == 0 && objtype == TYPE_MOB) {
+        auto PTargetList = (static_cast<CMobEntity*>(this))->PEnmityContainer->GetEnmityList();
+        for (const auto& Element : *PTargetList)
+        {
+            auto PEntity = Element.second.PEnmityOwner;
+            // ShowDebug("trying autotarget PEnt->Bat: %d  this: %d \n", (int)PEntity->GetBattleTarget(), (int)this);
+            if (PEntity->objtype == TYPE_PC && PEntity->GetBattleTarget() == this)
+            {
+                static_cast<CCharEntity*>(PEntity)->AutoTarget();
+            }
+        }
     }
 
     return abs(hp);

--- a/src/map/entities/charentity.h
+++ b/src/map/entities/charentity.h
@@ -351,6 +351,9 @@ public:
     bool hasMoghancement(uint16 moghancementID);
     void UpdateMoghancement();
 
+    /* call this when the mob I'm engaged on dies */
+    void AutoTarget();
+
     /* State callbacks */
     virtual bool CanAttack(CBattleEntity* PTarget, std::unique_ptr<CBasicPacket>& errMsg) override;
     virtual bool OnAttack(CAttackState&, action_t&) override;


### PR DESCRIPTION
fixes a bug where autotarget only works for the 1 player that gets the last hit
With this, autotarget works for everyone engaged, as it should.